### PR TITLE
fix: concept-id value translation everywhere (2.1.1)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dsOMOP
 Type: Package
 Title: DataSHIELD Server-Side Integration for OMOP CDM Databases
-Version: 2.1.0
+Version: 2.1.1
 Authors@R: c(
     person("David", "Sarrat González", role = c("aut", "cre"), email = "david.sarrat@isglobal.org"),
     person("Xavier", "Escribà-Montagut", role = "aut"),

--- a/R/extraction.R
+++ b/R/extraction.R
@@ -720,7 +720,7 @@
 
   result <- switch(representation,
     "long" = result,
-    "wide" = .toWide(result, table),
+    "wide" = .toWide(result, table, handle),
     "features" = .toFeatures(result, table, feature_specs),
     "sparse" = .toSparse(result, table),
     result
@@ -870,8 +870,8 @@
 #' @param table Character; source table name
 #' @return Data frame in wide format
 #' @keywords internal
-.toWide <- function(df, table) {
-  bp <- .buildBlueprint(get(".current_handle", envir = environment()) %||% NULL)
+.toWide <- function(df, table, handle = NULL) {
+  bp <- .buildBlueprint(handle)
   concept_col <- NULL
 
   # Try to find concept column from column names

--- a/R/extraction.R
+++ b/R/extraction.R
@@ -730,6 +730,15 @@
     result <- .applyDateHandling(result, date_handling)
   }
 
+  # "features" keeps raw pass-through concept columns (e.g. gender_concept_id);
+  # translate them so person-level frames and the factor-harmonization layer see
+  # readable names. Renamed aggregate columns no longer match *_concept_id, so
+  # .vocabTranslateColumns leaves them untouched.
+  if (translate_concepts && identical(representation, "features") &&
+      is.data.frame(result)) {
+    result <- .vocabTranslateColumns(handle, result)
+  }
+
   result
 }
 

--- a/R/profiling.R
+++ b/R/profiling.R
@@ -358,6 +358,23 @@
     result <- .suppressSmallCounts(result, "n")
   }
 
+  # Decorate categorical concept VALUES with human-readable names, so the row
+  # values themselves are translated (e.g. 8532 -> "Female"), not just labelled
+  # by column. Mirrors the prevalence path (.profileConceptPrevalence).
+  if (nrow(result) > 0 &&
+      (grepl("_concept_id$", column) || identical(column, "value_as_concept_id"))) {
+    ids <- suppressWarnings(as.integer(result$value))
+    concepts <- tryCatch(.vocabLookupConcepts(handle, ids[!is.na(ids)]),
+                         error = function(e) NULL)
+    if (!is.null(concepts) && nrow(concepts) > 0) {
+      cmap <- stats::setNames(concepts$concept_name,
+                              as.character(concepts$concept_id))
+      result$concept_name <- unname(cmap[as.character(result$value)])
+      miss <- is.na(result$concept_name)
+      result$concept_name[miss] <- paste0("concept_", result$value[miss])
+    }
+  }
+
   result
 }
 

--- a/man/dot-toWide.Rd
+++ b/man/dot-toWide.Rd
@@ -4,7 +4,7 @@
 \alias{.toWide}
 \title{Transform a long result to wide format}
 \usage{
-.toWide(df, table)
+.toWide(df, table, handle = NULL)
 }
 \arguments{
 \item{df}{Data frame in long format}


### PR DESCRIPTION
## Summary
Makes concept-id translation faithful at the **value** level (not just column level) across all surfaces, and repairs two related defects. Version bump 2.1.0 → 2.1.1.

- **value.counts / concept.summary**: categorical `*_concept_id` and `value_as_concept_id` distributions now carry a `concept_name` column (was raw ids 8532/8507). `profiling.R`.
- **wide representation**: `.toWide` was crashing because the vocabulary handle was never threaded in; now passed explicitly so wide output translates instead of erroring. `extraction.R`.
- **features / person-level**: raw pass-through concept columns (e.g. `gender_concept_id`) are now translated to readable names, which also lets the concept-factor harmonization layer build **name-valued** (not raw-id) factor levels across servers. `extraction.R`.

## Verification
- `devtools::test()`: **PASS 1724 / FAIL 0 / WARN 0** (1 pre-existing empty-test skip).
- Live DSLite+Postgres proofs: `condition_concept_id → "diabetes_mellitus"`; `gender_concept_id` features → factor levels `female | male` (not 8532/8507).

## Test plan
- [x] testthat suite green
- [x] translate_concepts proof (long)
- [x] factor-harmonization proof (features, name levels)
- [ ] end-to-end on real federation (gibleed + re-keyed MIMIC)