### PR TITLE
fix: full 256-bit person-key token (2.1.3)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dsOMOP
 Type: Package
 Title: DataSHIELD Server-Side Integration for OMOP CDM Databases
-Version: 2.1.2
+Version: 2.1.3
 Authors@R: c(
     person("David", "Sarrat González", role = c("aut", "cre"), email = "david.sarrat@isglobal.org"),
     person("Xavier", "Escribà-Montagut", role = "aut"),

--- a/R/interface.R
+++ b/R/interface.R
@@ -156,13 +156,14 @@
 #' @return Character vector of pseudonymous tokens.
 #' @keywords internal
 .hashPersonKey <- function(ids, salt) {
-  toks <- openssl::sha256(as.character(ids), key = salt)
-  # 32 hex chars = 128 bits. The previous 64-bit (16 hex) token had a birthday
-  # bound of ~2^32, so distinct persons collided with non-trivial probability at
-  # population scale (~3% at 1e9 persons). 128 bits pushes the bound to ~2^64,
-  # negligible for any conceivable cohort. as.character(ids) is now exact (ids
-  # are integer/character, never a rounded double — see .coerce_integer64).
-  substr(as.character(toks), 1L, 32L)
+  # Full 256-bit HMAC-SHA-256 digest (64 hex), NOT truncated. Birthday-collision
+  # bound ~n^2/2^257 is ~10^-60 at 1e9 persons — below any physical failure rate,
+  # so distinct ids yield distinct tokens for any conceivable cohort. (The earlier
+  # 64- and 128-bit truncations had real birthday odds at population scale: ~3% at
+  # 1e9 for 64-bit.) as.character(ids) is exact — integer/character, never a
+  # rounded double (see .coerce_integer64). The cardinality assertion in
+  # .pseudonymizeIdentifiers is belt-and-suspenders on top of this.
+  as.character(openssl::sha256(as.character(ids), key = salt))
 }
 
 #' Pseudonymize/strip row-level identifiers before DataSHIELD assignment

--- a/tests/testthat/test-bigint-personid.R
+++ b/tests/testthat/test-bigint-personid.R
@@ -31,10 +31,10 @@ test_that(".coerce_integer64 preserves precision (never a lossy double)", {
   expect_equal(length(unique(dsOMOP:::.coerce_integer64(pair)$pid)), 2L)
 })
 
-test_that(".hashPersonKey is a 128-bit token and injective on exact ids", {
+test_that(".hashPersonKey is a full 256-bit token and injective on exact ids", {
   salt <- as.raw(1:16)
   toks <- dsOMOP:::.hashPersonKey(c("9007199254740992", "9007199254740993"), salt)
-  expect_true(all(nchar(toks) == 32L))            # 32 hex = 128 bits
+  expect_true(all(nchar(toks) == 64L))            # 64 hex = full 256-bit SHA-256
   expect_equal(length(unique(toks)), 2L)          # distinct ids -> distinct tokens
 })
 


### PR DESCRIPTION
Emit the full 256-bit SHA-256 digest for the pseudonymous person key instead of truncating to 128 bits. Collision bound drops from ~1e-21 to ~1e-60 at 1e9 persons (physically irrelevant); deterministic and stateless, no UUID/FPE needed. Fail-closed cardinality assertion retained. Suite 1739/0.