### PR TITLE
fix: readable concept-name translations matching the catalog (2.1.4)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dsOMOP
 Type: Package
 Title: DataSHIELD Server-Side Integration for OMOP CDM Databases
-Version: 2.1.3
+Version: 2.1.4
 Authors@R: c(
     person("David", "Sarrat González", role = c("aut", "cre"), email = "david.sarrat@isglobal.org"),
     person("Xavier", "Escribà-Montagut", role = "aut"),

--- a/R/vocabulary.R
+++ b/R/vocabulary.R
@@ -306,9 +306,13 @@
     translated <- concept_map[original]
     translated[is.na(translated) & !is.na(original)] <-
       paste0("concept_", original[is.na(translated) & !is.na(original)])
-    translated <- vapply(translated, .standardizeName, character(1),
-                         USE.NAMES = FALSE)
-    df[[col]] <- translated
+    # Keep the human-readable concept_name verbatim, so the VALUE shown here
+    # matches the catalog (value.counts / concept.prevalence / concept.summary)
+    # exactly. Do NOT standardize the value: .standardizeName is for turning a
+    # concept into a syntactically-valid COLUMN NAME, which .toWide/.toFeatures
+    # apply independently at the naming step (and idempotently), so wide/feature
+    # headers stay clean regardless.
+    df[[col]] <- unname(translated)
   }
 
   df

--- a/tests/testthat/test-output-contracts.R
+++ b/tests/testthat/test-output-contracts.R
@@ -111,8 +111,9 @@ test_that("baseline with concept translation works", {
     result <- .planExecute(handle, plan, list(demo = "demo_df"))
     df <- result$demo
     expect_true(is.data.frame(df))
-    # Gender concept IDs should be translated to names
-    expect_true(all(df$gender_concept_id %in% c("male", "female")))
+    # Gender concept IDs are translated to the readable concept_name verbatim,
+    # matching the catalog (value.counts etc.) — not a standardized form.
+    expect_true(all(df$gender_concept_id %in% c("MALE", "FEMALE")))
   })
 })
 


### PR DESCRIPTION
Translated *_concept_id / value_as_concept_id VALUES now keep the human-readable concept_name verbatim (e.g. "Sinus rhythm", "Resistant", "FEMALE"), identical to the catalog (value.counts / concept.prevalence / concept.summary). Previously the extraction standardized them ("sinus_rhythm") causing a cross-surface mismatch. Wide/feature COLUMN names stay standardized (applied independently at the naming step). Suite 1739/0.