### PR TITLE
concept_id filter for numeric histogram/range aggregates (2.2.4)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dsOMOP
 Type: Package
 Title: DataSHIELD Server-Side Integration for OMOP CDM Databases
-Version: 2.2.3
+Version: 2.2.4
 Authors@R: c(
     person("David", "Sarrat González", role = c("aut", "cre"), email = "david.sarrat@isglobal.org"),
     person("Xavier", "Escribà-Montagut", role = "aut"),

--- a/R/interface.R
+++ b/R/interface.R
@@ -1004,6 +1004,8 @@ omopCrossTabDS <- function(omop_symbol, table, row_col, col_col,
 #' @param value_col Character; numeric column name
 #' @param cohort_table Character; cohort temp table for filtering (NULL)
 #' @param window List with start/end dates for filtering (NULL)
+#' @param concept_id Integer; optional; restrict the range to rows of this
+#'   concept, using the table's domain concept column
 #' @return List with p05, p95, n_total
 #' @examples
 #' \dontrun{
@@ -1011,9 +1013,13 @@ omopCrossTabDS <- function(omop_symbol, table, row_col, col_col,
 #' }
 #' @export
 omopNumericRangeDS <- function(omop_symbol, table, value_col,
-                                cohort_table = NULL, window = NULL) {
+                                cohort_table = NULL, window = NULL,
+                                concept_id = NULL) {
   handle <- .getHandle(omop_symbol)
-  .profileNumericRange(handle, table, value_col, cohort_table, window)
+  concept_id <- .ds_arg(concept_id)
+  if (!is.null(concept_id)) concept_id <- as.integer(unlist(concept_id))
+  .profileNumericRange(handle, table, value_col, cohort_table, window,
+                       concept_id = concept_id)
 }
 
 #' Get numeric histogram (Aggregate)
@@ -1030,6 +1036,8 @@ omopNumericRangeDS <- function(omop_symbol, table, value_col,
 #' @param cohort_table Character; cohort temp table for filtering (NULL)
 #' @param window List with start/end dates for filtering (NULL)
 #' @param breaks Numeric vector; shared bin edges from two-pass pooling (NULL)
+#' @param concept_id Integer; optional; restrict the histogram to rows of this
+#'   concept, using the table's domain concept column
 #' @return Data frame with bin_start, bin_end, count, suppressed
 #' @examples
 #' \dontrun{
@@ -1038,11 +1046,15 @@ omopNumericRangeDS <- function(omop_symbol, table, value_col,
 #' @export
 omopNumericHistogramDS <- function(omop_symbol, table, value_col,
                                     bins = 20L, cohort_table = NULL,
-                                    window = NULL, breaks = NULL) {
+                                    window = NULL, breaks = NULL,
+                                    concept_id = NULL) {
   handle <- .getHandle(omop_symbol)
   breaks <- .ds_arg(breaks)
+  concept_id <- .ds_arg(concept_id)
+  if (!is.null(concept_id)) concept_id <- as.integer(unlist(concept_id))
   .profileNumericHistogram(handle, table, value_col, bins,
-                           cohort_table, window, breaks)
+                           cohort_table, window, breaks,
+                           concept_id = concept_id)
 }
 
 #' Get numeric quantiles (Aggregate)

--- a/R/profiling.R
+++ b/R/profiling.R
@@ -667,7 +667,8 @@
 #' @return List with p05, p95, n_total
 #' @keywords internal
 .profileNumericRange <- function(handle, table, value_col,
-                                  cohort_table = NULL, window = NULL) {
+                                  cohort_table = NULL, window = NULL,
+                                  concept_id = NULL) {
   table <- tolower(.validateIdentifier(table, "table"))
   value_col <- tolower(.validateIdentifier(value_col, "column"))
   bp <- .buildBlueprint(handle)
@@ -706,6 +707,17 @@
                          paste0("t.", date_col, " <= ", .quoteLiteral(window$end)))
       }
     }
+  }
+
+  # Optional concept scope: restrict to one concept of this table.
+  if (!is.null(concept_id)) {
+    ccol <- .getDomainConceptColumn(bp, table)
+    if (is.null(ccol)) {
+      stop("Table '", table, "' has no concept column to scope by.",
+           call. = FALSE)
+    }
+    where_parts <- c(where_parts,
+                     paste0("t.", ccol, " = ", as.integer(concept_id)))
   }
 
   where_sql <- paste0(" WHERE ", paste(where_parts, collapse = " AND "))
@@ -773,7 +785,8 @@
 #' @keywords internal
 .profileNumericHistogram <- function(handle, table, value_col,
                                       bins = 20L, cohort_table = NULL,
-                                      window = NULL, breaks = NULL) {
+                                      window = NULL, breaks = NULL,
+                                      concept_id = NULL) {
   table <- tolower(.validateIdentifier(table, "table"))
   value_col <- tolower(.validateIdentifier(value_col, "column"))
   bp <- .buildBlueprint(handle)
@@ -819,6 +832,17 @@
                          paste0("t.", date_col, " <= ", .quoteLiteral(window$end)))
       }
     }
+  }
+
+  # Optional concept scope: restrict to one concept of this table.
+  if (!is.null(concept_id)) {
+    ccol <- .getDomainConceptColumn(bp, table)
+    if (is.null(ccol)) {
+      stop("Table '", table, "' has no concept column to scope by.",
+           call. = FALSE)
+    }
+    where_parts <- c(where_parts,
+                     paste0("t.", ccol, " = ", as.integer(concept_id)))
   }
 
   where_sql <- paste0(" WHERE ", paste(where_parts, collapse = " AND "))

--- a/man/dot-profileNumericHistogram.Rd
+++ b/man/dot-profileNumericHistogram.Rd
@@ -11,7 +11,8 @@
   bins = 20L,
   cohort_table = NULL,
   window = NULL,
-  breaks = NULL
+  breaks = NULL,
+  concept_id = NULL
 )
 }
 \arguments{

--- a/man/dot-profileNumericRange.Rd
+++ b/man/dot-profileNumericRange.Rd
@@ -9,7 +9,8 @@
   table,
   value_col,
   cohort_table = NULL,
-  window = NULL
+  window = NULL,
+  concept_id = NULL
 )
 }
 \arguments{

--- a/man/omopNumericHistogramDS.Rd
+++ b/man/omopNumericHistogramDS.Rd
@@ -11,7 +11,8 @@ omopNumericHistogramDS(
   bins = 20L,
   cohort_table = NULL,
   window = NULL,
-  breaks = NULL
+  breaks = NULL,
+  concept_id = NULL
 )
 }
 \arguments{
@@ -28,6 +29,9 @@ omopNumericHistogramDS(
 \item{window}{List with start/end dates for filtering (NULL)}
 
 \item{breaks}{Numeric vector; shared bin edges from two-pass pooling (NULL)}
+
+\item{concept_id}{Integer; optional; restrict the histogram to rows of this
+concept, using the table's domain concept column}
 }
 \value{
 Data frame with bin_start, bin_end, count, suppressed

--- a/man/omopNumericRangeDS.Rd
+++ b/man/omopNumericRangeDS.Rd
@@ -9,7 +9,8 @@ omopNumericRangeDS(
   table,
   value_col,
   cohort_table = NULL,
-  window = NULL
+  window = NULL,
+  concept_id = NULL
 )
 }
 \arguments{
@@ -22,6 +23,9 @@ omopNumericRangeDS(
 \item{cohort_table}{Character; cohort temp table for filtering (NULL)}
 
 \item{window}{List with start/end dates for filtering (NULL)}
+
+\item{concept_id}{Integer; optional; restrict the range to rows of this
+concept, using the table's domain concept column}
 }
 \value{
 List with p05, p95, n_total


### PR DESCRIPTION
Adds an optional `concept_id` to `omopNumericHistogramDS` / `omopNumericRangeDS` so a numeric distribution can be scoped to a single concept (e.g. Heart rate) instead of mixing `value_as_number` across a whole table. Powers the per-concept Numeric Distribution view in OMOP Studio. Disclosure controls unchanged. Server suite 439/0.