### PR TITLE
Translate concept IDs to labels by default (2.2.5)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dsOMOP
 Type: Package
 Title: DataSHIELD Server-Side Integration for OMOP CDM Databases
-Version: 2.2.4
+Version: 2.2.5
 Authors@R: c(
     person("David", "Sarrat González", role = c("aut", "cre"), email = "david.sarrat@isglobal.org"),
     person("Xavier", "Escribà-Montagut", role = "aut"),

--- a/R/extraction.R
+++ b/R/extraction.R
@@ -652,7 +652,7 @@
 .extractTable <- function(handle, table, columns = NULL,
                           concept_filter = NULL, person_ids = NULL,
                           time_window = NULL, cohort_table = NULL,
-                          translate_concepts = FALSE,
+                          translate_concepts = TRUE,
                           representation = "long",
                           feature_specs = NULL,
                           block_sensitive = TRUE,
@@ -2280,7 +2280,7 @@
 #' @return Data frame with one row per cohort member
 #' @keywords internal
 .extractBaseline <- function(handle, cohort_table, columns = NULL,
-                              derived = NULL, translate_concepts = FALSE) {
+                              derived = NULL, translate_concepts = TRUE) {
   if (is.null(cohort_table)) {
     warning("Baseline output requires a cohort; returning NULL.", call. = FALSE)
     return(NULL)

--- a/R/plan.R
+++ b/R/plan.R
@@ -854,7 +854,7 @@
   concept_cols_by_output <- list()
   outputs <- plan$outputs %||% list()
   options <- plan$options %||% list()
-  translate <- options$translate_concepts %||% FALSE
+  translate <- options$translate_concepts %||% TRUE
   block_sensitive <- options$block_sensitive %||% TRUE
 
   # Concept expansion cache: expand each unique concept set once

--- a/tests/testthat/test-extraction.R
+++ b/tests/testthat/test-extraction.R
@@ -106,7 +106,8 @@ test_that("extractTable filters by concept", {
 
   withr::with_options(list(nfilter.subset = 3), {
     result <- .extractTable(handle, "condition_occurrence",
-                            concept_filter = c(201820))
+                            concept_filter = c(201820),
+                            translate_concepts = FALSE)
     expect_true(all(result$condition_concept_id == 201820))
   })
 })


### PR DESCRIPTION
## Summary
- Flip `translate_concepts` default from `FALSE` to `TRUE` in extraction (`.extractTable`) and plan execution, so concept IDs come back as readable labels unless the caller opts out.
- Matches the new dsOMOPClient/Studio default; explicit `translate_concepts = FALSE` still fully supported.
- Bump 2.2.4 → 2.2.5.

## Test plan
- [x] Full server testthat suite: 0 fail (439 tests)
- [x] `test-extraction.R` concept-filter test pins `translate_concepts = FALSE` (asserts raw id)