### PR TITLE
Expose optional results_schema in the resource form (2.2.6)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dsOMOP
 Type: Package
 Title: DataSHIELD Server-Side Integration for OMOP CDM Databases
-Version: 2.2.5
+Version: 2.2.6
 Authors@R: c(
     person("David", "Sarrat González", role = c("aut", "cre"), email = "david.sarrat@isglobal.org"),
     person("Xavier", "Escribà-Montagut", role = "aut"),

--- a/inst/resources/resource.js
+++ b/inst/resources/resource.js
@@ -31,6 +31,10 @@ var dsOMOP = (function () {
     key: "vocabulary_schema", type: "string", title: "Vocabulary schema (optional)",
     description: "Schema holding the vocabulary tables, when separate from the CDM schema. Defaults to the CDM schema."
   };
+  var resultsSchema = {
+    key: "results_schema", type: "string", title: "Results schema (optional)",
+    description: "Schema holding generated result tables (Achilles, Data Quality Dashboard, and other OHDSI/HADES outputs). Defaults to the CDM schema, or the engine default when no CDM schema is set."
+  };
   var warehouse = {
     key: "warehouse", type: "string", title: "Warehouse (optional)",
     description: "Snowflake virtual warehouse. Defaults to COMPUTE_WH."
@@ -39,7 +43,7 @@ var dsOMOP = (function () {
     key: "driver", type: "string", title: "ODBC driver (optional)",
     description: "ODBC driver name to override the engine default."
   };
-  var SCHEMAS = [cdmSchema, vocabularySchema];
+  var SCHEMAS = [cdmSchema, vocabularySchema, resultsSchema];
 
   // --- credentials blocks ---------------------------------------------------
   // Every type MUST carry a credentials block, even when none is needed: a type
@@ -170,6 +174,7 @@ var dsOMOP = (function () {
     }
     addQuery("cdm_schema", params.cdm_schema);
     addQuery("vocabulary_schema", params.vocabulary_schema);
+    addQuery("results_schema", params.results_schema);
     addQuery("warehouse", params.warehouse);
     addQuery("driver", params.driver);
     var qs = query.length > 0 ? ("?" + query.join("&")) : "";

--- a/tests/testthat/test-resource.R
+++ b/tests/testthat/test-resource.R
@@ -11,6 +11,16 @@ test_that(".parseOmopUrl parses a full server URL", {
   expect_equal(p$vocabulary_schema, "vocab")
 })
 
+test_that(".parseOmopUrl parses results_schema (and its 'results' alias)", {
+  p <- .parseOmopUrl(
+    "omop+dbi:postgresql://db.example.org:5432/omop?cdm_schema=cdm&results_schema=res")
+  expect_equal(p$cdm_schema, "cdm")
+  expect_equal(p$results_schema, "res")
+  expect_equal(
+    .parseOmopUrl("omop+dbi:postgresql://h:5432/omop?results=res")$results_schema,
+    "res")
+})
+
 test_that(".parseOmopUrl accepts a bare scheme (no omop+dbi wrapper)", {
   p <- .parseOmopUrl("postgresql://omopdb:5432/omop?cdm_schema=cdm")
   expect_equal(p$dbms, "postgresql")
@@ -119,6 +129,16 @@ test_that("schema resolution case 4: both set -> one each", {
     .parseOmopUrl("omop+dbi:postgresql://h:5432/omop?cdm_schema=cdm&vocabulary_schema=vocab")))
   expect_equal(h$cdm_schema, "cdm")
   expect_equal(h$vocab_schema, "vocab")
+})
+
+test_that("results_schema from the URL is stored as an explicit pin on the handle", {
+  h <- .createHandle(fake_client(.parseOmopUrl(
+    "omop+dbi:postgresql://h:5432/omop?cdm_schema=cdm&results_schema=res")))
+  expect_equal(h$results_schema, "res")
+  # Not declared -> no pin (effective schema is resolved later, falling back to CDM).
+  h2 <- .createHandle(fake_client(.parseOmopUrl(
+    "omop+dbi:postgresql://h:5432/omop?cdm_schema=cdm")))
+  expect_null(h2$results_schema)
 })
 
 test_that("schema resolution uses the connecting user for Oracle's default", {


### PR DESCRIPTION
## Summary
- Add an optional **Results schema** field to the Opal resource constructor (`inst/resources/resource.js`) and emit `results_schema` in the resource URL.
- The R backend already parses/stores/resolves `results_schema` (Achilles, Data Quality Dashboard, other OHDSI/HADES result tables), falling back to the CDM schema then the engine default — this just surfaces it in the create-resource form.
- Bump 2.2.5 → 2.2.6.

## Test plan
- [x] `test-resource.R`: 0 fail (50 tests; +2 new — URL parse of `results_schema`/`results` alias, handle pin)
- [x] `resource.js` parses cleanly (node)
- [x] Full server suite: 0 fail